### PR TITLE
Make CMake build system more platform-independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,16 @@ set(CMAKE_BENCH_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/benchmark/include)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
 
+# Define an interface target for the Vc library
+add_library(Vc INTERFACE)
+target_include_directories(Vc INTERFACE ${Vc_INCLUDE_DIR})
+target_link_libraries(Vc INTERFACE libVc.a -L${Vc_LIB_DIR})
+
+# Define an interface target for the core code
+add_library(Core INTERFACE)
+target_include_directories(Core INTERFACE ${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_SOURCE_DIR}/include/)
+target_compile_features(Core INTERFACE cxx_std_17)
+
 # General compile options
 add_compile_options(
        -O3 --std=c++17

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,32 +3,27 @@
   set(_target "UnitTest${_name}")
   add_executable(${_target} ${ARGN})
 
-  target_compile_features(${_target} PUBLIC cxx_std_17)
-
   # define required BOOST_TEST_... macros here to ensure consistent names
   target_compile_definitions(
     ${_target}
-    PRIVATE "-DBOOST_TEST_DYN_LINK" "-DBOOST_TEST_MODULE=${_target}")
- 
-  target_include_directories(
-   ${_target}
-   SYSTEM PUBLIC ${EIGEN_INCLUDE_DIRS}
-  )
-
-  target_include_directories(${_target} 
-   PRIVATE ${CMAKE_INSTALL_INCLUDEDIR}
+    PRIVATE "-DBOOST_TEST_DYN_LINK" "-DBOOST_TEST_MODULE=${_target}"
   )
 
   target_include_directories(
     ${_target}
-    PRIVATE Core ${CMAKE_CURRENT_SOURCE_DIR})
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 
   target_link_libraries(
     ${_target}
     PRIVATE
-      Boost::unit_test_framework Boost::timer
-      benchmark::benchmark
-      libVc.a)
+    Core
+    Boost::unit_test_framework Boost::timer
+    benchmark::benchmark
+    Vc
+    Eigen3::Eigen
+  )
+
   # register as unittest executable
   add_test(NAME ${_name} COMMAND ${_target})
 endmacro()
@@ -38,37 +33,28 @@ macro(add_benchmark _name)
   set(_target "Benchmark${_name}")
   add_executable(${_target} ${ARGN})
 
-  target_compile_features(${_target} PUBLIC cxx_std_17)
-
   target_compile_definitions(
     ${_target}
-    PRIVATE "-DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON" "-DBENCHMARK_ENABLE_GTEST_TESTS=OFF")
+    PRIVATE "-DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON" "-DBENCHMARK_ENABLE_GTEST_TESTS=OFF"
+  )
 
   add_compile_options(-pthread)
 
-  target_include_directories(${_target} 
-   PRIVATE ${CMAKE_BENCH_INCLUDEDIR}
-  )
- 
-  target_include_directories(
-   ${_target}
-   SYSTEM PUBLIC ${EIGEN_INCLUDE_DIRS}
-  )
-
-  target_include_directories(${_target} 
-   PRIVATE ${CMAKE_INSTALL_INCLUDEDIR}
-  )
-
   target_include_directories(
     ${_target}
-    PRIVATE Core ${CMAKE_CURRENT_SOURCE_DIR})
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 
   target_link_libraries(
     ${_target}
     PRIVATE
-      benchmark::benchmark
-      benchmark::benchmark_main
-      libVc.a)
+    Core
+    benchmark::benchmark
+    benchmark::benchmark_main
+    Vc
+    Eigen3::Eigen
+  )
+
   # register as unittest executable
   add_test(NAME ${_name} COMMAND ${_target})
 endmacro()

--- a/src/IntersectionBenchmark.cpp
+++ b/src/IntersectionBenchmark.cpp
@@ -1,8 +1,8 @@
  /**
  * author: joana.niermann@cern.ch
  **/
-#include <types.hpp>
-#include <intersectors.hpp>
+#include "types.hpp"
+#include "intersectors.hpp"
 
 #ifdef DEBUG
 #include <chrono>

--- a/src/IntersectionTests.cpp
+++ b/src/IntersectionTests.cpp
@@ -1,8 +1,8 @@
  /**
  * author: joana.niermann@cern.ch
  **/
-#include <types.hpp>
-#include <intersectors.hpp>
+#include "types.hpp"
+#include "intersectors.hpp"
 
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
I was having a lot of problems building the code, because CMake couldn't find some of the libraries on my system. I've taken the liberty of modifying the CMake code a little bit to make sure it works on my machine, and hopefully this will make it more easy to compile on other people's machines as well!